### PR TITLE
[Nodejs] Updating `Prisma` version and using YBDB `prisma-adapter` for smart driver.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ By default, the REST API server listens on `localhost` port `8080`.
 You can create a user named `John Smith` and email `jsmith@example.com` as follows:
 
 ```
-$ curl --data '{ "firstName" : "John", "lastName" : "Smith", "email" : "jsmith@example.com" }' \
+curl --data '{ "firstName" : "John", "lastName" : "Smith", "email" : "jsmith@example.com" }' \
        -v -X POST -H 'Content-Type:application/json' http://localhost:8080/users
 ```
 
@@ -64,7 +64,7 @@ postgres=# select * from users;
 
 You can list the current set of users by running the following:
 ```
-$ curl http://localhost:8080/users
+curl http://localhost:8080/users
 ```
 
 You should see the following output:
@@ -86,7 +86,7 @@ You should see the following output:
 
 You can create a product listing as follows:
 ```
-$ curl \
+curl \
   --data '{ "productName": "Notebook", "description": "200 page notebook", "price": 7.50 }' \
   -v -X POST -H 'Content-Type:application/json' http://localhost:8080/products
 ```
@@ -104,7 +104,7 @@ You should see the following return value:
 
 You can do this as follows:
 ```
-$ curl http://localhost:8080/products
+curl http://localhost:8080/products
 ```
 
 You should see an output as follows:
@@ -132,7 +132,12 @@ $ curl \
 
 You should see the following return value:
 ```
-TBD
+{
+  "orderId": "686eca4c-f880-480b-b8f2-6a3041de4142",
+  "userId": "1",
+  "orderTotal": "15",
+  "orderLines": "[{"orderId":"686eca4c-f880-480b-b8f2-6a3041de4142","productId":1,"quantity":2}]"
+}
 ```
 
 Note that you can check out multiple products in one order. As an example, the following POST payload makes one user (id=1) checkout two products (id=1 and id=2) by creating the following payload:

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ You should see the following return value:
   "productId": "1",
   "productName": "Notebook",
   "description": "200 page, hardbound, blank notebook",
-  "price": 7.5}
+  "price": 7.5
+}
 ```
 
 ## Step 6. List all products

--- a/node/prisma/.env
+++ b/node/prisma/.env
@@ -1,1 +1,1 @@
-DATABASE_URL="postgresql://yugabyte:yugabyte@127.0.0.1:5433/ysql_prisma"
+DATABASE_URL="postgresql://yugabyte:yugabyte@127.0.0.1:5433/ysql_prisma?ybServersRefreshInterval=10&loadBalance=true"

--- a/node/prisma/.gitignore
+++ b/node/prisma/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 prisma/migrations
 package-lock.json
+app.log

--- a/node/prisma/README.md
+++ b/node/prisma/README.md
@@ -12,7 +12,7 @@ Note: By default, app tries to connect to the local cluster with `ysql_prisma` d
 
 Install depedencies by running :
 ```
-$ cd node/prisma && npm install
+cd node/prisma && npm install
 ```
 
 Create the tables in the YugabyteDB by applying the migration for the data models in the file `prisma/schema.prisma` using the following command and generate the `PrismaClient`: 
@@ -32,5 +32,5 @@ export LOG_LEVEL=silly
 
 To run the server, simply do:
 ```
-$ npm start
+npm start
 ```

--- a/node/prisma/README.md
+++ b/node/prisma/README.md
@@ -24,6 +24,12 @@ Note: If you want to use the Prisma CLI without `npx`, you need to install Prism
 npm i -g prisma
 ``` 
 
+Note: If you want to enable driver logs, you need to install `winston` and set the log level: 
+```
+npm install winston
+export LOG_LEVEL=silly
+```
+
 To run the server, simply do:
 ```
 $ npm start

--- a/node/prisma/package.json
+++ b/node/prisma/package.json
@@ -6,14 +6,15 @@
     "start": "node app.js"
   },
   "dependencies": {
-    "@prisma/client": "^3.14.0",
+    "@prisma/client": "^6.8.2",
+    "@yugabytedb/prisma-adapter": "6.8.2-yb-1",
     "cookie-parser": "~1.4.3",
     "debug": "~2.6.9",
     "express": "~4.16.0",
     "http-errors": "~1.6.2",
     "jade": "~1.11.0",
     "morgan": "~1.9.0",
-    "prisma": "^3.14.0",
+    "prisma": "^6.8.2",
     "uuid": "^3.3.2"
   }
 }

--- a/node/prisma/package.json
+++ b/node/prisma/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@prisma/client": "^6.8.2",
-    "@yugabytedb/prisma-adapter": "6.8.2-yb-1",
+    "@yugabytedb/prisma-adapter": "6.8.2-yb-2",
     "cookie-parser": "~1.4.3",
     "debug": "~2.6.9",
     "express": "~4.16.0",

--- a/node/prisma/prisma/schema.prisma
+++ b/node/prisma/prisma/schema.prisma
@@ -3,6 +3,7 @@
 
 generator client {
   provider = "prisma-client-js"
+  previewFeatures = ["driverAdapters"]
 }
 
 datasource db {

--- a/node/prisma/routes/orders.js
+++ b/node/prisma/routes/orders.js
@@ -1,11 +1,15 @@
 'use strict';
 var express = require('express');
 var router = express.Router();
-const { PrismaClient }  = require('@prisma/client')
 
-const prisma = new PrismaClient({
-  log: ['query', 'info', 'warn', 'error'],
-})
+const { PrismaPg } = require('@yugabytedb/prisma-adapter');
+const { PrismaClient } = require('@prisma/client');
+
+const connectionString = `${process.env.DATABASE_URL}`
+
+const adapter = new PrismaPg({ connectionString })
+
+const prisma = new PrismaClient({ adapter })
 
 
 router.get('/', function(req, res, next) {

--- a/node/prisma/routes/products.js
+++ b/node/prisma/routes/products.js
@@ -1,11 +1,14 @@
 'use strict';
 var express = require('express');
 var router = express.Router();
-const { PrismaClient }  = require('@prisma/client')
+const { PrismaPg } = require('@yugabytedb/prisma-adapter');
+const { PrismaClient } = require('@prisma/client');
 
-const prisma = new PrismaClient({
-  log: ['query', 'info', 'warn', 'error'],
-})
+const connectionString = `${process.env.DATABASE_URL}`
+
+const adapter = new PrismaPg({ connectionString })
+
+const prisma = new PrismaClient({ adapter })
 
 router.get('/', function(req, res, next) {
     prisma.product

--- a/node/prisma/routes/users.js
+++ b/node/prisma/routes/users.js
@@ -1,11 +1,14 @@
 'use strict';
 var express = require('express');
 var router = express.Router();
-const { PrismaClient }  = require('@prisma/client')
+const { PrismaPg } = require('@yugabytedb/prisma-adapter');
+const { PrismaClient } = require('@prisma/client');
 
-const prisma = new PrismaClient({
-  log: ['query', 'info', 'warn', 'error'],
-})
+const connectionString = `${process.env.DATABASE_URL}`
+
+const adapter = new PrismaPg({ connectionString })
+
+const prisma = new PrismaClient({ adapter })
 
 router.get('/', function(req, res, next) {
     prisma.user


### PR DESCRIPTION
The following PR:

- Updates Prisma version since driverAdapters preview feature in not supported in 3.14.0
- Uses YugabyteDB prisma-adapter to enable usage of node-postgres smart driver.